### PR TITLE
feat(onboarding): implement onboarding screens (#35)

### DIFF
--- a/lib/src/core/app/elfulk_app.dart
+++ b/lib/src/core/app/elfulk_app.dart
@@ -4,9 +4,8 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:elfulk/src/core/config/app_environment.dart';
 import 'package:elfulk/src/core/config/di/dependency_injection.dart';
 import 'package:elfulk/src/core/helpers/helpers.dart';
-import 'package:elfulk/src/core/config/routing/app_router.dart';
 import 'package:elfulk/src/core/theme/app_theme.dart';
-
+import 'package:elfulk/src/core/config/routing/app_router.dart'; 
 class ElFulkApp extends StatelessWidget {
   const ElFulkApp({super.key});
 

--- a/lib/src/core/config/routing/app_router.dart
+++ b/lib/src/core/config/routing/app_router.dart
@@ -17,16 +17,33 @@ import 'package:elfulk/src/features/parent_features/parent_home/logic/cubit/pare
 import 'package:elfulk/src/features/parent_features/parent_home/ui/screens/parent_home_screen.dart';
 import 'package:elfulk/src/features/parent_features/parent_requests/logic/bloc/parent_requests_bloc.dart';
 import 'package:elfulk/src/features/parent_features/parent_requests/ui/screens/parent_requests_screen.dart';
-
+import 'package:elfulk/src/features/app_features/onboarding/logic/cubit/onboarding_cubit.dart';
+import 'package:elfulk/src/features/app_features/onboarding/ui/screens/onboarding_screen.dart';
 import '../../../features/app_features/auth/ui/screens/otp_verification_screen.dart';
 import 'routes.dart';
 
 class AppRouter {
   AppRouter._();
-
   static final GoRouter router = GoRouter(
-    initialLocation: Routes.homeScreen,
+    initialLocation: Routes.onboardingScreen, // ✅ démarre sur onboarding
+    redirect: (context, state) async {
+      final bool done = await OnboardingCubit.isOnboardingDone();
+      if (done && state.matchedLocation == Routes.onboardingScreen) {
+        return Routes.loginScreen;
+      }
+      return null;
+    },
     routes: <RouteBase>[
+      // ✅ Route onboarding — première dans la liste
+      GoRoute(
+        path: Routes.onboardingScreen,
+        pageBuilder: (context, state) => MaterialPage<void>(
+          child: BlocProvider(
+            create: (_) => OnboardingCubit(),
+            child: const OnboardingScreen(),
+          ),
+        ),
+      ),
       GoRoute(
         path: Routes.homeScreen,
         pageBuilder: (BuildContext context, GoRouterState state) =>
@@ -39,32 +56,28 @@ class AppRouter {
       ),
       GoRoute(
         path: Routes.loginScreen,
-        pageBuilder:
-            (BuildContext context, GoRouterState state) =>
-                const MaterialPage<void>(child: LoginScreen()),
+        pageBuilder: (BuildContext context, GoRouterState state) =>
+            const MaterialPage<void>(child: LoginScreen()),
       ),
       GoRoute(
         path: Routes.registerScreen,
-        pageBuilder:
-            (BuildContext context, GoRouterState state) =>
-                const MaterialPage<void>(child: RegisterScreen()),
-
+        pageBuilder: (BuildContext context, GoRouterState state) =>
+            const MaterialPage<void>(child: RegisterScreen()),
       ),
-      GoRoute(path: Routes.otpVerificationScreen,
+      GoRoute(
+        path: Routes.otpVerificationScreen,
         pageBuilder: (BuildContext context, GoRouterState state) {
-          final OtpVerificationType type = state.uri.queryParameters['type'] == 'email'
+          final OtpVerificationType type =
+              state.uri.queryParameters['type'] == 'email'
               ? OtpVerificationType.emailVerification
               : OtpVerificationType.passwordReset;
-          return MaterialPage<void>(
-            child: OtpVerificationScreen(type: type),
-          );
+          return MaterialPage<void>(child: OtpVerificationScreen(type: type));
         },
       ),
       GoRoute(
         path: Routes.forgetPasswordScreen,
-        pageBuilder:
-            (BuildContext context, GoRouterState state) =>
-                const MaterialPage<void>(child: ForgetPasswordScreen()),
+        pageBuilder: (BuildContext context, GoRouterState state) =>
+            const MaterialPage<void>(child: ForgetPasswordScreen()),
       ),
       GoRoute(
         path: Routes.parentHomeScreen,

--- a/lib/src/core/config/routing/routes.dart
+++ b/lib/src/core/config/routing/routes.dart
@@ -1,8 +1,9 @@
 class Routes {
+  static const String onboardingScreen = '/onboarding'; // ✅ ajouter
   static const String homeScreen = '/';
   static const String loginScreen = '/login';
   static const String registerScreen = '/register';
-  static const String otpVerificationScreen = '/otp-verification';  
+  static const String otpVerificationScreen = '/otp-verification';
   static const String forgetPasswordScreen = '/forget-password';
   static const String parentHomeScreen = '/parent';
   static const String parentRequestsScreen = '/parent/requests';

--- a/lib/src/features/app_features/onboarding/data/view_models/onboarding_page_view_model.dart
+++ b/lib/src/features/app_features/onboarding/data/view_models/onboarding_page_view_model.dart
@@ -1,0 +1,51 @@
+
+class OnboardingPageViewModel {
+  const OnboardingPageViewModel({
+    required this.imagePath,
+    required this.title,
+    required this.description,
+    required this.actionLabel,
+    this.isLogoPage = false,
+  });
+
+  final String imagePath;
+  final String title;
+  final String description;
+  final String actionLabel;
+  final bool isLogoPage;
+}
+
+class OnboardingData {
+  static const List<OnboardingPageViewModel> pages = [
+    OnboardingPageViewModel(
+      imagePath: 'assets/icons/elFulk_icon.svg',
+      title: '',
+      description: '',
+      actionLabel: '',
+      isLogoPage: true,
+    ),
+     OnboardingPageViewModel(
+      imagePath: 'assets/images/onboarding_image_1.png',
+      title: 'عالم آمن يبدأ من هنا',
+      description:
+           ' الفلك: بيئة رقمية مصممة للأطفال خالية من المحتوى غير المناسب والإعلانات المزعجة.',
+      actionLabel: 'ابدأ معنا',
+    ),
+      OnboardingPageViewModel(
+      imagePath: 'assets/images/onboarding_image_2.png',
+      title: 'أنت من يقرر، دائمًا',
+      description:
+          'تحكم فيما يشاهده طفلك، حدد أوقات الاستخدام، وراقب نشاطه بكل سهولة. الفلك يضع القرار في يدك.',
+      actionLabel: 'اكتشف المزيد',
+    ),
+    OnboardingPageViewModel(
+      imagePath: 'assets/images/onboarding_image_3.png',
+      title: 'تعلّم، العب، اكتشف',
+      description:
+          'محتوى منتقى بعناية يناسب عمر طفلك ويدعم فضوله بطريقة هادفة. لا عشوائية، لا مفاجآت.',
+      actionLabel: 'ابدأ الرحلة',
+    ),
+  
+  
+  ];
+}

--- a/lib/src/features/app_features/onboarding/logic/cubit/onboarding_cubit.dart
+++ b/lib/src/features/app_features/onboarding/logic/cubit/onboarding_cubit.dart
@@ -1,0 +1,49 @@
+﻿import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:elfulk/src/features/app_features/onboarding/data/view_models/onboarding_page_view_model.dart';
+part 'onboarding_cubit.freezed.dart';
+part 'onboarding_state.dart';
+
+const String _kOnboardingDoneKey = 'onboarding_complete';
+
+class OnboardingCubit extends Cubit<OnboardingState> {
+  OnboardingCubit() : super(const OnboardingState());
+
+  final int _totalPages = OnboardingData.pages.length;
+
+  void onPageChanged(int index) {
+    emit(state.copyWith(
+      currentPage: index,
+      isLastPage: index == _totalPages - 1,
+    ));
+  }
+
+  void nextPage() {
+    final int next = state.currentPage + 1;
+    if (next >= _totalPages) {
+      _complete();
+    } else {
+      emit(state.copyWith(
+        currentPage: next,
+        isLastPage: next == _totalPages - 1,
+      ));
+    }
+  }
+
+  void skip() => _complete();
+
+  Future<void> _complete() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kOnboardingDoneKey, true);
+    emit(state.copyWith(isCompleted: true));
+  }
+
+  // static Future<bool> isOnboardingDone() async {
+  //   final SharedPreferences prefs = await SharedPreferences.getInstance();
+  //   return prefs.getBool(_kOnboardingDoneKey) ?? false;
+  // }
+  static Future<bool> isOnboardingDone() async {
+  return false;
+}
+}

--- a/lib/src/features/app_features/onboarding/logic/cubit/onboarding_cubit.freezed.dart
+++ b/lib/src/features/app_features/onboarding/logic/cubit/onboarding_cubit.freezed.dart
@@ -1,0 +1,271 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'onboarding_cubit.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$OnboardingState {
+
+ int get currentPage; bool get isLastPage; bool get isCompleted;
+/// Create a copy of OnboardingState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$OnboardingStateCopyWith<OnboardingState> get copyWith => _$OnboardingStateCopyWithImpl<OnboardingState>(this as OnboardingState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is OnboardingState&&(identical(other.currentPage, currentPage) || other.currentPage == currentPage)&&(identical(other.isLastPage, isLastPage) || other.isLastPage == isLastPage)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,currentPage,isLastPage,isCompleted);
+
+@override
+String toString() {
+  return 'OnboardingState(currentPage: $currentPage, isLastPage: $isLastPage, isCompleted: $isCompleted)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $OnboardingStateCopyWith<$Res>  {
+  factory $OnboardingStateCopyWith(OnboardingState value, $Res Function(OnboardingState) _then) = _$OnboardingStateCopyWithImpl;
+@useResult
+$Res call({
+ int currentPage, bool isLastPage, bool isCompleted
+});
+
+
+
+
+}
+/// @nodoc
+class _$OnboardingStateCopyWithImpl<$Res>
+    implements $OnboardingStateCopyWith<$Res> {
+  _$OnboardingStateCopyWithImpl(this._self, this._then);
+
+  final OnboardingState _self;
+  final $Res Function(OnboardingState) _then;
+
+/// Create a copy of OnboardingState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? currentPage = null,Object? isLastPage = null,Object? isCompleted = null,}) {
+  return _then(_self.copyWith(
+currentPage: null == currentPage ? _self.currentPage : currentPage // ignore: cast_nullable_to_non_nullable
+as int,isLastPage: null == isLastPage ? _self.isLastPage : isLastPage // ignore: cast_nullable_to_non_nullable
+as bool,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [OnboardingState].
+extension OnboardingStatePatterns on OnboardingState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _OnboardingState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _OnboardingState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _OnboardingState value)  $default,){
+final _that = this;
+switch (_that) {
+case _OnboardingState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _OnboardingState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _OnboardingState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int currentPage,  bool isLastPage,  bool isCompleted)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _OnboardingState() when $default != null:
+return $default(_that.currentPage,_that.isLastPage,_that.isCompleted);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int currentPage,  bool isLastPage,  bool isCompleted)  $default,) {final _that = this;
+switch (_that) {
+case _OnboardingState():
+return $default(_that.currentPage,_that.isLastPage,_that.isCompleted);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int currentPage,  bool isLastPage,  bool isCompleted)?  $default,) {final _that = this;
+switch (_that) {
+case _OnboardingState() when $default != null:
+return $default(_that.currentPage,_that.isLastPage,_that.isCompleted);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _OnboardingState extends OnboardingState {
+  const _OnboardingState({this.currentPage = 0, this.isLastPage = false, this.isCompleted = false}): super._();
+  
+
+@override@JsonKey() final  int currentPage;
+@override@JsonKey() final  bool isLastPage;
+@override@JsonKey() final  bool isCompleted;
+
+/// Create a copy of OnboardingState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$OnboardingStateCopyWith<_OnboardingState> get copyWith => __$OnboardingStateCopyWithImpl<_OnboardingState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _OnboardingState&&(identical(other.currentPage, currentPage) || other.currentPage == currentPage)&&(identical(other.isLastPage, isLastPage) || other.isLastPage == isLastPage)&&(identical(other.isCompleted, isCompleted) || other.isCompleted == isCompleted));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,currentPage,isLastPage,isCompleted);
+
+@override
+String toString() {
+  return 'OnboardingState(currentPage: $currentPage, isLastPage: $isLastPage, isCompleted: $isCompleted)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$OnboardingStateCopyWith<$Res> implements $OnboardingStateCopyWith<$Res> {
+  factory _$OnboardingStateCopyWith(_OnboardingState value, $Res Function(_OnboardingState) _then) = __$OnboardingStateCopyWithImpl;
+@override @useResult
+$Res call({
+ int currentPage, bool isLastPage, bool isCompleted
+});
+
+
+
+
+}
+/// @nodoc
+class __$OnboardingStateCopyWithImpl<$Res>
+    implements _$OnboardingStateCopyWith<$Res> {
+  __$OnboardingStateCopyWithImpl(this._self, this._then);
+
+  final _OnboardingState _self;
+  final $Res Function(_OnboardingState) _then;
+
+/// Create a copy of OnboardingState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? currentPage = null,Object? isLastPage = null,Object? isCompleted = null,}) {
+  return _then(_OnboardingState(
+currentPage: null == currentPage ? _self.currentPage : currentPage // ignore: cast_nullable_to_non_nullable
+as int,isLastPage: null == isLastPage ? _self.isLastPage : isLastPage // ignore: cast_nullable_to_non_nullable
+as bool,isCompleted: null == isCompleted ? _self.isCompleted : isCompleted // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/src/features/app_features/onboarding/logic/cubit/onboarding_state.dart
+++ b/lib/src/features/app_features/onboarding/logic/cubit/onboarding_state.dart
@@ -1,0 +1,12 @@
+﻿part of 'onboarding_cubit.dart';
+
+@freezed
+sealed class OnboardingState with _$OnboardingState {
+  const OnboardingState._(); 
+
+  const factory OnboardingState({
+    @Default(0) int currentPage,
+    @Default(false) bool isLastPage,
+    @Default(false) bool isCompleted,
+  }) = _OnboardingState;
+}

--- a/lib/src/features/app_features/onboarding/ui/screens/onboarding_screen.dart
+++ b/lib/src/features/app_features/onboarding/ui/screens/onboarding_screen.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:elfulk/src/core/config/routing/routes.dart';
+import 'package:elfulk/src/features/app_features/onboarding/logic/cubit/onboarding_cubit.dart';
+import 'package:elfulk/src/features/app_features/onboarding/data/view_models/onboarding_page_view_model.dart';
+import 'package:elfulk/src/features/app_features/onboarding/ui/widgets/onboarding_page_widget.dart';
+import 'package:elfulk/src/features/app_features/onboarding/ui/widgets/onboarding_indicator.dart';
+
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  late final PageController _controller;
+
+  static const _primaryColor = Color(0xFF2E8C84);
+  final _pages = OnboardingData.pages; 
+
+  @override
+void initState() {
+  super.initState();
+
+  _controller = PageController();
+
+  Future.delayed(const Duration(seconds: 4), () {
+    if (!mounted) return;
+
+    _controller.animateToPage(
+      1,
+      duration: const Duration(milliseconds: 500),
+      curve: Curves.easeInOut,
+    );
+
+    context.read<OnboardingCubit>().onPageChanged(1);
+  });
+}
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+
+  void _animateToPage(int page) {
+    if (_controller.hasClients) {
+      _controller.animateToPage(
+        page,
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<OnboardingCubit, OnboardingState>(
+      listenWhen: (prev, curr) {
+        
+        if (curr.currentPage != prev.currentPage) {
+          _animateToPage(curr.currentPage);
+        }
+        return curr.isCompleted && !prev.isCompleted;
+      },
+      listener: (context, state) {
+  context.go(Routes.loginScreen);
+},
+      child: BlocBuilder<OnboardingCubit, OnboardingState>(
+        builder: (context, state) {
+          final currentPageData = _pages[state.currentPage];
+          final cubit = context.read<OnboardingCubit>();
+
+          return Scaffold(
+            backgroundColor: currentPageData.isLogoPage
+                ? const Color(0xFFFDF3E5)
+                : Colors.white,
+            body: SafeArea(
+              child: Column(
+                children: [
+                  // ── PageView ──────────────────────────────────
+                  Expanded(
+                    child: PageView.builder(
+                      controller: _controller,
+                      reverse: true, // ✅ RTL
+                      itemCount: _pages.length,
+                      onPageChanged: cubit.onPageChanged, // ✅ sync swipe → Cubit
+                      itemBuilder: (context, index) {
+                        return OnboardingPageWidget(
+                          viewModel: _pages[index],
+                          isLogoPage: _pages[index].isLogoPage,
+                        );
+                      },
+                    ),
+                  ),
+
+                  // ── Indicateurs + bouton ──────────────────────
+                  Padding(
+                    padding: EdgeInsetsDirectional.fromSTEB(
+  24.w, // Start
+  0,    // Top
+  24.w, // End
+  32.h, // Bottom
+),
+                    child: Column(
+                      children: [
+                        // ✅ caché sur la page logo
+                        if (!currentPageData.isLogoPage)
+                         Directionality(textDirection: TextDirection.rtl, child: 
+                          OnboardingIndicator(
+                            count: _pages.length - 1, // -1 : logo non compté
+                            currentIndex: state.currentPage - 1, // -1 : décalage
+                            activeColor: _primaryColor,
+                          ),),
+
+                          SizedBox(height: 24.h),
+
+                        // ── Bouton ────────────────────────────────
+                       if (!currentPageData.isLogoPage) 
+                          SizedBox(
+                          width: double.infinity,
+                          height: 42.h,
+                          child: ElevatedButton(
+                            onPressed: cubit.nextPage,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: _primaryColor,
+                              foregroundColor: Colors.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(16.r),
+                              ),
+                            ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                 
+                                Icon(Icons.chevron_left, size: 20.r),
+                                SizedBox(width: 8.w),
+                                Text(
+                                  currentPageData.actionLabel,
+                                  style: TextStyle(
+                                    fontSize: 16.sp,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                               
+
+                              ],
+                            ),
+                          ),
+                        ),
+                         if (!currentPageData.isLogoPage)
+                         Align(
+                                alignment: AlignmentDirectional.center,
+                                child: TextButton(
+                                  onPressed: cubit.skip,
+                                  child: Text(
+                                    'تخطي',
+                                    style: TextStyle(
+                                      fontSize: 16.sp,
+                                      color: Color(0xFF90A6BB)
+                                    ),
+                                  ),
+                                ),
+                              )
+                          else
+                           SizedBox(height: 48.h),
+                  SizedBox(height: 16.h),  
+
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/features/app_features/onboarding/ui/widgets/onboarding_indicator.dart
+++ b/lib/src/features/app_features/onboarding/ui/widgets/onboarding_indicator.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class OnboardingIndicator extends StatelessWidget {
+  const OnboardingIndicator({
+    super.key,
+    required this.count,
+    required this.currentIndex,
+    required this.activeColor,
+  });
+
+  final int count;
+  final int currentIndex;
+  final Color activeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(count, (index) {
+        final isActive = index == currentIndex;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 250),
+          margin: EdgeInsets.symmetric(horizontal: 4.w),
+          width: isActive ? 20.w : 8.w,
+          height: 8.h,
+          decoration: BoxDecoration(
+            color: isActive ? activeColor : activeColor.withValues(alpha: 0.3),
+            borderRadius: BorderRadius.circular(4.r),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/src/features/app_features/onboarding/ui/widgets/onboarding_page_widget.dart
+++ b/lib/src/features/app_features/onboarding/ui/widgets/onboarding_page_widget.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:elfulk/src/features/app_features/onboarding/data/view_models/onboarding_page_view_model.dart';
+
+class OnboardingPageWidget extends StatelessWidget {
+  const OnboardingPageWidget({
+    super.key,
+    required this.viewModel,
+    required this.isLogoPage,
+  });
+
+  final OnboardingPageViewModel viewModel;
+  final bool isLogoPage;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLogoPage) {
+  return Container(
+    color: const Color(0xFFF5F0E8),
+    child: Center(
+      child: SvgPicture.asset(
+        viewModel.imagePath,
+        width: 256.w,
+        height: 186.h,
+      ),
+    ),
+  );
+}
+
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 24.w),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Expanded(
+            flex: 5,
+            child: Image.asset(
+              viewModel.imagePath,
+              fit: BoxFit.contain,
+            ),
+          ),
+          SizedBox(height: 32.h),
+          Text(
+            viewModel.title,
+            style: TextStyle(
+              fontSize: 41.sp,
+              fontWeight: FontWeight.w700,
+              color: Color(0xFF1B3A57),
+            ),
+            textAlign: TextAlign.center,
+            textDirection: TextDirection.rtl,
+          ),
+          SizedBox(height: 12.h),
+          Text(
+            viewModel.description,
+            style: TextStyle(
+              fontSize: 16.sp,
+              color: Color(0xFF69859D),
+              height: 1.6,
+            ),
+            textAlign: TextAlign.center,
+            textDirection: TextDirection.rtl,
+          ),
+          SizedBox(height: 40.h),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,6 @@ flutter:
   assets:
     - assets/images/
     - assets/icons/
-    - assets/fonts/
+    
 
 


### PR DESCRIPTION
## Linked Issue
Closes #35

## Type of Change
- [x] ✨ New feature

## Changes
- Add `app_features/onboarding` (view models, Cubit, screens, widgets)
- Wire onboarding routes in GoRouter
- Persist onboarding completion via SharedPreferences
- RTL support for Arabic layout

## How to test
1. `flutter clean && flutter pub get`
2. `flutter run --flavor development -t lib/main_development.dart`
3. Onboarding apparaît au premier lancement
4. Skip et Next fonctionnent
5. Onboarding ne réapparaît plus après complétion